### PR TITLE
Fix Checkbox Parsing for REDCaps without Whitespace

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -101,7 +101,8 @@ parse_labels <- function(string, return_vector = FALSE) {
   }
 
   out <- string %>%
-    strsplit(" \\| ") # Split by "|"
+    strsplit("\\|") %>%  # Split by "|"
+    lapply(trimws) # Trim trailing and leading whitespace in list elements
 
   # Check there is a comma in all | delimited strsplit elements
   if (!all(grepl(",", out[[1]]))) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -77,7 +77,7 @@ test_that("multi_choice_to_labels works", {
 
 test_that("parse_labels works", {
   # Note: implicitly testing strip_html_field_embedding() by checking that
-  # parse_labels successfully stipes html tags and field embedding logic
+  # parse_labels successfully stips html tags and field embedding logic
   valid_string <- "choice_1, one | choice_2, two {abc} | choice_3, <b>three</b>"
   valid_tibble_output <- tibble::tribble(
     ~raw,       ~label,
@@ -111,6 +111,10 @@ test_that("parse_labels works", {
     parse_labels(warning_string_1),
     class = "empty_parse_warning"
   )
+
+  # Check that parse_labels can account for splits where no white space exists
+  valid_string_no_ws <- "choice_1, one|choice_2, two {abc}|choice_3, <b>three</b>"
+  expect_equal(parse_labels(valid_string_no_ws), valid_tibble_output)
 })
 
 test_that("link_arms works", {


### PR DESCRIPTION
# Description
This PR provides a simple, base R fix to address REDCap parsing issues in cases where databases do not have white space around the `|` character split. 

# Proposed Changes 
List changes below in bullet format:

- Update `parse_labels` so split occurs on `|` and not `<space>|<space> `
- Secondarily remove white space using `lapply(trimws)` from base R

**Screenshots**
The test database from Will's example credentials file that brought this into question now returns `redcap_data` as expected

### Before Proposed Fix:
![image](https://user-images.githubusercontent.com/38384694/207646168-9b370f66-038e-461f-875f-a90aab5fd4f0.png)

### With Proposed Fix Implemented:
![image](https://user-images.githubusercontent.com/38384694/207645967-cce3d79a-0e2b-4cec-9547-ccf7ab1cafff.png)

### Issue Addressed
**Closes #105**

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [NA] New/revised functions have associated tests
- [NA] New/revised functions that update downstream outputs have associated static testing files (`.RDS`) updated under `inst/testdata/create_test_data.R`
- [NA] New tests that make API calls use `httptest::with_mock_api` and any new mocks were added to `tests/testthat/fixtures/create_httptest_mocks.R`
- [NA] New/revised functions use appropriate naming conventions
- [x] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases
