### PR TITLE
Fix supress_redcapr_messages Bug

### DIFF
--- a/R/read_redcap.R
+++ b/R/read_redcap.R
@@ -76,7 +76,11 @@ read_redcap <- function(redcap_uri,
   db_metadata <- redcap_metadata_read(
     redcap_uri = redcap_uri,
     token = token,
-    verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}
+    verbose = if (suppress_redcapr_messages) {
+      FALSE
+    } else {
+      TRUE
+    }
   )$data %>%
     filter(.data$field_type != "descriptive")
 
@@ -143,7 +147,11 @@ read_redcap <- function(redcap_uri,
     token = token,
     forms = forms_for_api_call,
     export_survey_fields = export_survey_fields,
-    verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}
+    verbose = if (suppress_redcapr_messages) {
+      FALSE
+    } else {
+      TRUE
+    }
   )$data
 
   # Check that results were returned
@@ -316,7 +324,11 @@ add_metadata <- function(supertbl, db_metadata, redcap_uri, token, suppress_redc
   instrument_labs <- redcap_instruments(
     redcap_uri,
     token,
-    verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}
+    verbose = if (suppress_redcapr_messages) {
+      FALSE
+    } else {
+      TRUE
+    }
   )$data %>%
     rename(
       redcap_form_label = "instrument_label",

--- a/R/read_redcap.R
+++ b/R/read_redcap.R
@@ -76,7 +76,7 @@ read_redcap <- function(redcap_uri,
   db_metadata <- redcap_metadata_read(
     redcap_uri = redcap_uri,
     token = token,
-    verbose = FALSE
+    verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}
   )$data %>%
     filter(.data$field_type != "descriptive")
 
@@ -143,7 +143,7 @@ read_redcap <- function(redcap_uri,
     token = token,
     forms = forms_for_api_call,
     export_survey_fields = export_survey_fields,
-    verbose = FALSE
+    verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}
   )$data
 
   # Check that results were returned
@@ -206,7 +206,8 @@ read_redcap <- function(redcap_uri,
   }
 
   if (is_longitudinal) {
-    linked_arms <- link_arms(redcap_uri = redcap_uri, token = token)
+    linked_arms <- link_arms(redcap_uri = redcap_uri, token = token,
+                             suppress_redcapr_messages = suppress_redcapr_messages)
 
     out <- clean_redcap_long(
       db_data_long = db_data,
@@ -221,7 +222,7 @@ read_redcap <- function(redcap_uri,
   }
 
   # Augment with metadata ----
-  out <- add_metadata(out, db_metadata, redcap_uri, token)
+  out <- add_metadata(out, db_metadata, redcap_uri, token, suppress_redcapr_messages)
 
   if (is_longitudinal) {
     out <- add_event_mapping(out, linked_arms)
@@ -286,6 +287,8 @@ get_fields_to_drop <- function(db_metadata, form) {
 #'
 #' @param supertbl a supertibble object to supplement with metadata
 #' @param db_metadata a REDCap metadata tibble
+#' @param suppress_redcapr_messages A logical to control whether to suppress messages
+#' from REDCapR API calls. Default `TRUE`.
 #' @inheritParams read_redcap
 #'
 #' @details This function assumes that \code{db_metadata} has been processed to
@@ -308,12 +311,12 @@ get_fields_to_drop <- function(db_metadata, form) {
 #'
 #' @keywords internal
 
-add_metadata <- function(supertbl, db_metadata, redcap_uri, token) {
+add_metadata <- function(supertbl, db_metadata, redcap_uri, token, suppress_redcapr_messages) {
   # Get instrument labels ----
   instrument_labs <- redcap_instruments(
     redcap_uri,
     token,
-    verbose = FALSE
+    verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}
   )$data %>%
     rename(
       redcap_form_label = "instrument_label",

--- a/R/read_redcap.R
+++ b/R/read_redcap.R
@@ -76,11 +76,7 @@ read_redcap <- function(redcap_uri,
   db_metadata <- redcap_metadata_read(
     redcap_uri = redcap_uri,
     token = token,
-    verbose = if (suppress_redcapr_messages) {
-      FALSE
-    } else {
-      TRUE
-    }
+    verbose = !suppress_redcapr_messages
   )$data %>%
     filter(.data$field_type != "descriptive")
 
@@ -147,11 +143,7 @@ read_redcap <- function(redcap_uri,
     token = token,
     forms = forms_for_api_call,
     export_survey_fields = export_survey_fields,
-    verbose = if (suppress_redcapr_messages) {
-      FALSE
-    } else {
-      TRUE
-    }
+    verbose = !suppress_redcapr_messages
   )$data
 
   # Check that results were returned
@@ -324,11 +316,7 @@ add_metadata <- function(supertbl, db_metadata, redcap_uri, token, suppress_redc
   instrument_labs <- redcap_instruments(
     redcap_uri,
     token,
-    verbose = if (suppress_redcapr_messages) {
-      FALSE
-    } else {
-      TRUE
-    }
+    verbose = !suppress_redcapr_messages
   )$data %>%
     rename(
       redcap_form_label = "instrument_label",

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,6 +43,8 @@ add_partial_keys <- function(db_data,
 #'
 #' @param redcap_uri The REDCap URI
 #' @param token The REDCap API token
+#' @param suppress_redcapr_messages A logical to control whether to suppress messages
+#' from REDCapR API calls. Default `TRUE`.
 #'
 #' @importFrom dplyr rename left_join
 #' @importFrom REDCapR redcap_event_instruments redcap_arm_export
@@ -50,8 +52,9 @@ add_partial_keys <- function(db_data,
 #' @keywords internal
 
 link_arms <- function(redcap_uri,
-                      token) {
-  arms <- redcap_arm_export(redcap_uri, token, verbose = FALSE)$data %>%
+                      token,
+                      suppress_redcapr_messages) {
+  arms <- redcap_arm_export(redcap_uri, token, verbose = if(suppress_redcapr_messages){FALSE}else{TRUE})$data %>%
     # match field name of redcap_event_instruments() output
     rename(arm_num = "arm_number")
 
@@ -59,7 +62,7 @@ link_arms <- function(redcap_uri,
     redcap_uri = redcap_uri,
     token = token,
     arms = NULL, # get all arms
-    verbose = FALSE
+    verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}
   )$data
 
   left_join(db_event_instruments, arms, by = "arm_num")

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,7 +53,7 @@ add_partial_keys <- function(db_data,
 
 link_arms <- function(redcap_uri,
                       token,
-                      suppress_redcapr_messages) {
+                      suppress_redcapr_messages = TRUE) {
   arms <- redcap_arm_export(redcap_uri, token, verbose = if(suppress_redcapr_messages){FALSE}else{TRUE})$data %>%
     # match field name of redcap_event_instruments() output
     rename(arm_num = "arm_number")

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,11 +54,7 @@ add_partial_keys <- function(db_data,
 link_arms <- function(redcap_uri,
                       token,
                       suppress_redcapr_messages = TRUE) {
-  arms <- redcap_arm_export(redcap_uri, token, verbose = if (suppress_redcapr_messages) {
-    FALSE
-  } else {
-    TRUE
-  })$data %>%
+  arms <- redcap_arm_export(redcap_uri, token, verbose = !suppress_redcapr_messages)$data %>%
     # match field name of redcap_event_instruments() output
     rename(arm_num = "arm_number")
 
@@ -66,11 +62,7 @@ link_arms <- function(redcap_uri,
     redcap_uri = redcap_uri,
     token = token,
     arms = NULL, # get all arms
-    verbose = if (suppress_redcapr_messages) {
-      FALSE
-    } else {
-      TRUE
-    }
+    verbose = !suppress_redcapr_messages
   )$data
 
   left_join(db_event_instruments, arms, by = "arm_num")

--- a/R/utils.R
+++ b/R/utils.R
@@ -54,7 +54,11 @@ add_partial_keys <- function(db_data,
 link_arms <- function(redcap_uri,
                       token,
                       suppress_redcapr_messages = TRUE) {
-  arms <- redcap_arm_export(redcap_uri, token, verbose = if(suppress_redcapr_messages){FALSE}else{TRUE})$data %>%
+  arms <- redcap_arm_export(redcap_uri, token, verbose = if (suppress_redcapr_messages) {
+    FALSE
+  } else {
+    TRUE
+  })$data %>%
     # match field name of redcap_event_instruments() output
     rename(arm_num = "arm_number")
 
@@ -62,7 +66,11 @@ link_arms <- function(redcap_uri,
     redcap_uri = redcap_uri,
     token = token,
     arms = NULL, # get all arms
-    verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}
+    verbose = if (suppress_redcapr_messages) {
+      FALSE
+    } else {
+      TRUE
+    }
   )$data
 
   left_join(db_event_instruments, arms, by = "arm_num")
@@ -99,7 +107,7 @@ parse_labels <- function(string, return_vector = FALSE) {
   # If string is empty/NA, throw a warning
   if (is.na(string)) {
     cli_warn("Empty string detected for a given multiple choice label.",
-      class = c("empty_parse_warning", "REDCapTidieR_cond")
+             class = c("empty_parse_warning", "REDCapTidieR_cond")
     )
   }
 

--- a/man/add_metadata.Rd
+++ b/man/add_metadata.Rd
@@ -4,7 +4,13 @@
 \alias{add_metadata}
 \title{Supplement a supertibble with additional metadata fields}
 \usage{
-add_metadata(supertbl, db_metadata, redcap_uri, token)
+add_metadata(
+  supertbl,
+  db_metadata,
+  redcap_uri,
+  token,
+  suppress_redcapr_messages
+)
 }
 \arguments{
 \item{supertbl}{a supertibble object to supplement with metadata}
@@ -17,6 +23,9 @@ URI/URL of the REDCap server (e.g.,
 
 \item{token}{The user-specific string that serves as the password for a
 project. Required.}
+
+\item{suppress_redcapr_messages}{A logical to control whether to suppress messages
+from REDCapR API calls. Default \code{TRUE}.}
 }
 \value{
 The original supertibble with additional fields:

--- a/man/link_arms.Rd
+++ b/man/link_arms.Rd
@@ -4,7 +4,7 @@
 \alias{link_arms}
 \title{Link longitudinal REDCap instruments with their events/arms}
 \usage{
-link_arms(redcap_uri, token, suppress_redcapr_messages)
+link_arms(redcap_uri, token, suppress_redcapr_messages = TRUE)
 }
 \arguments{
 \item{redcap_uri}{The REDCap URI}

--- a/man/link_arms.Rd
+++ b/man/link_arms.Rd
@@ -4,12 +4,15 @@
 \alias{link_arms}
 \title{Link longitudinal REDCap instruments with their events/arms}
 \usage{
-link_arms(redcap_uri, token)
+link_arms(redcap_uri, token, suppress_redcapr_messages)
 }
 \arguments{
 \item{redcap_uri}{The REDCap URI}
 
 \item{token}{The REDCap API token}
+
+\item{suppress_redcapr_messages}{A logical to control whether to suppress messages
+from REDCapR API calls. Default \code{TRUE}.}
 }
 \value{
 Returns a \code{tibble} of \code{redcap_event_name}s with list elements


### PR DESCRIPTION
# Description
This PR provides a quick solution to `suppress_redcapr_messages`, which currently does not get fed to any REDCapR API calls since we set `verbose = FALSE` for everything. 

A funny side effect of the way we named this argument is that REDCapR `verbose` and REDCapTidieR `suppress` mean the opposite things, so it isn't a 1:1 slot in. Instead all API calls now have `verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}` to switch the logic and line up with how our argument reads. 

> I.e., if we **do** want messages suppressed, then we **don't** want REDCapR to be verbose and vice-versa.

I have not written a test for this, I'm not sure for something this small we need one, but am open to writing one up if desired. Also left a note about the bullet "New/revised functions don't repeat code" in the checklist.

# Proposed Changes 
List changes below in bullet format:

- Update all REDCapR API function calls from `verbose = FALSE` to `verbose = if(suppress_redcapr_messages){FALSE}else{TRUE}`
- Add `suppress_redcapr_messages` as a parameter for applicable functions where it wasn't one before

### Issue Addressed
**Closes #104**

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [NA] New/revised functions have associated tests
- [NA] New/revised functions that update downstream outputs have associated static testing files (`.RDS`) updated under `inst/testdata/create_test_data.R`
- [NA] New tests that make API calls use `httptest::with_mock_api` and any new mocks were added to `tests/testthat/fixtures/create_httptest_mocks.R`
- [NA] New/revised functions use appropriate naming conventions
- [ ] New/revised functions don't repeat code
   - Technically repeats conditional switching logic at all API calls
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases
