### PR TITLE
Include select_choices_or_calculations in Metadata Fields

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: REDCapTidieR
 Type: Package
 Title: Extract 'REDCap' Databases into Tidy 'Tibble's
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: c(
     person("Richard", "Hanna", , "richardshanna91@gmail.com", role = c("aut", "cre")),
     person("Stephan", "Kadauke", , "kadaukes@chop.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# REDCapTidieR (development version)
+
 Version 0.2.0 (Released 2022-12-07)
 ==========================================================
 

--- a/R/read_redcap.R
+++ b/R/read_redcap.R
@@ -335,10 +335,9 @@ add_metadata <- function(supertbl, db_metadata, redcap_uri, token, suppress_redc
 
   # Process metadata ----
   db_metadata <- db_metadata %>%
-    # At this stage select_choices_or_calculations has been unpacked into
-    # field_name_updated so we can drop it. Likewise, field_name has a subset
-    # of info from field_name_updated
-    select(!c("field_name", "select_choices_or_calculations")) %>%
+    # remove field_name since it has been unpacked into field_name_updated
+    # via update_field_names()
+    select(!"field_name") %>%
     rename(
       field_name = "field_name_updated",
       redcap_form_name = "form_name"


### PR DESCRIPTION
# Description
This PR introduces a very small update where we previously were dropping the `select_choices_or_calculations` variable from the REDCapR metadata return. The original thought was that since values here are unpacked and spread into the updated `field_name`s, we no longer needed it. Recently we found it would be helpful to have, so are reitintroducing it.

One thing to note is that for checkbox fields, the value of `select_choice_or_calculations` is repeated across our extrapolated checkbox `field_name`s:

```r
> db[[4]][[4]] %>% select(field_name, select_choices_or_calculations)
# A tibble: 29 × 2
   field_name            select_choices_or_calculations                                                               
   <chr>                 <chr>                                                                                        
 1 record_id             NA                                                                                           
 2 text                  NA                                                                                           
 3 note                  NA                                                                                           
 4 calculated            1+1                                                                                          
 5 dropdown_single       choice_1, one | choice_2, two | choice_3, three                                              
 6 radio_single          choice_1, A | choice_2, B | choice_3, C                                                      
 7 checkbox_multiple___1 1, 1 | 2, 2 | 3, 3 | 4, 4 | 5, 5 | 6, 6 | 7, 7 | 8, 8 | 9, 9 | 10, 10 | -99, Unknown | -98, …
 8 checkbox_multiple___2 1, 1 | 2, 2 | 3, 3 | 4, 4 | 5, 5 | 6, 6 | 7, 7 | 8, 8 | 9, 9 | 10, 10 | -99, Unknown | -98, …
 9 checkbox_multiple___3 1, 1 | 2, 2 | 3, 3 | 4, 4 | 5, 5 | 6, 6 | 7, 7 | 8, 8 | 9, 9 | 10, 10 | -99, Unknown | -98, …
10 checkbox_multiple___4 1, 1 | 2, 2 | 3, 3 | 4, 4 | 5, 5 | 6, 6 | 7, 7 | 8, 8 | 9, 9 | 10, 10 | -99, Unknown | -98, …
# … with 19 more rows
# ℹ Use `print(n = ...)` to see more rows
```

# Proposed Changes 
List changes below in bullet format:

- Remove deselection of `select_choices_or_calculations` from `select` statement in `read_redcap()`

### Issue Addressed
**Closes #108**

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [NA] New/revised functions have associated tests
- [NA] New/revised functions that update downstream outputs have associated static testing files (`.RDS`) updated under `inst/testdata/create_test_data.R`
- [NA] New tests that make API calls use `httptest::with_mock_api` and any new mocks were added to `tests/testthat/fixtures/create_httptest_mocks.R`
- [NA] New/revised functions use appropriate naming conventions
- [NA] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR
- [x]  Pre-release package version incremented using `usethis::use_dev_version()`

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases
