### PR TITLE
Lint in test suite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
     httptest,
     knitr,
     labelled,
+    lintr,
     readr,
     rmarkdown,
     testthat (>= 3.0.0)

--- a/tests/testthat/test-lint-free.R
+++ b/tests/testthat/test-lint-free.R
@@ -1,0 +1,3 @@
+test_that("package is lint free", {
+  lintr::expect_lint_free()
+})


### PR DESCRIPTION
This PR adds the lint check to our test suite with `expect_lint_free()` and remove the GHA
