### PR TITLE
Remove whitespace after comma in `parse_labels()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: REDCapTidieR
 Type: Package
 Title: Extract 'REDCap' Databases into Tidy 'Tibble's
-Version: 0.2.0.9001
+Version: 0.2.0.9002
 Authors@R: c(
     person("Richard", "Hanna", , "richardshanna91@gmail.com", role = c("aut", "cre")),
     person("Stephan", "Kadauke", , "kadaukes@chop.edu", role = "aut"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -136,7 +136,8 @@ parse_labels <- function(string, return_vector = FALSE, return_stripped_text_fla
   # split on the _first_ comma in each element
   out <- out %>%
     unlist() %>%
-    stri_split_fixed(pattern = ", ", n = 2) %>% # Split by first ","
+    stri_split_fixed(pattern = ",", n = 2) %>% # Split by first ","
+    lapply(trimws) %>%
     unlist()
 
   # Check if vector is even for matrix creation. If not, then fail.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -91,8 +91,6 @@ test_that("parse_labels works", {
 
   invalid_string_1 <- "raw, label | that has | pipes but no other | commas"
 
-  invalid_string_2 <- "raw, label | structure, | with odd, matrix dimensions"
-
   warning_string_1 <- NA_character_
 
   expect_equal(parse_labels(valid_string), valid_tibble_output)
@@ -104,18 +102,20 @@ test_that("parse_labels works", {
     parse_labels(invalid_string_1),
     class = "comma_parse_error"
   )
-  expect_error(
-    parse_labels(invalid_string_2),
-    class = "matrix_parse_error"
-  )
   expect_warning(
     parse_labels(warning_string_1),
     class = "empty_parse_warning"
   )
 
   # Check that parse_labels can account for splits where no white space exists
-  valid_string_no_ws <- "choice_1, one|choice_2, two {abc}|choice_3, <b>three</b>"
-  expect_equal(parse_labels(valid_string_no_ws), valid_tibble_output)
+
+  ## between pipes
+  valid_string_no_ws1 <- "choice_1, one|choice_2, two {abc}|choice_3, <b>three</b>"
+  expect_equal(parse_labels(valid_string_no_ws1), valid_tibble_output)
+
+  ## between commas
+  valid_string_no_ws2 <- "choice_1,one|choice_2,two {abc}|choice_3,<b>three</b>"
+  expect_equal(parse_labels(valid_string_no_ws2), valid_tibble_output)
 
   # Check that return_stripped_text_flag works
 


### PR DESCRIPTION
# Description
This PR updated `parse_labels()` to allow for `raw, label` specifications that don't have a whitespace trailing the comma (`raw, label`)

# Proposed Changes 
List changes below in bullet format:

- Remove explicit whitespace and trim whitespace afterwards
- Added test case and removed a test case that now does not error due to this change

### Issue Addressed
Closes #128 

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [x] New/revised functions have associated tests
- [x] New/revised functions that update downstream outputs have associated static testing files (`.RDS`) updated under `inst/testdata/create_test_data.R`
- [x] New tests that make API calls use `httptest::with_mock_api` and any new mocks were added to `tests/testthat/fixtures/create_httptest_mocks.R`
- [x] New/revised functions use appropriate naming conventions
- [x] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR
- [x] Pre-release package version incremented using `usethis::use_dev_version()`

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases
