### PR TITLE
Improve create repeat instance vars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: REDCapTidieR
 Type: Package
 Title: Extract 'REDCap' Databases into Tidy 'Tibble's
-Version: 0.2.0.9004
+Version: 0.2.0.9005
 Authors@R: c(
     person("Richard", "Hanna", , "richardshanna91@gmail.com", role = c("aut", "cre")),
     person("Stephan", "Kadauke", , "kadaukes@chop.edu", role = "aut"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,21 +82,24 @@ create_repeat_instance_vars <- function(db_data) {
     has_repeat_events <- FALSE
   }
 
-
   if (has_repeat_events) {
-    out <- out %>%
-      mutate(
-        # create event column first
-        redcap_event_instance = case_when(
-          is.na(redcap_repeat_instrument) &  !is.na(redcap_form_instance) ~ #nolint: object_usage_linter
-            redcap_form_instance,
-          TRUE ~ NA),
-        # then remove event values from form column
-        redcap_form_instance = case_when(
-          is.na(redcap_repeat_instrument) & !is.na(redcap_form_instance) ~ NA,
-          TRUE ~ redcap_form_instance)
-      ) %>%
-      relocate("redcap_event_instance", .after = "redcap_form_instance") #nolint: object_usage_linter
+    out$redcap_event_instance <- ifelse(
+      is.na(out$redcap_repeat_instrument) &
+        !is.na(out$redcap_form_instance),
+      out$redcap_form_instance,
+      NA
+    )
+
+    out$redcap_form_instance <- ifelse(
+      is.na(out$redcap_repeat_instrument) &
+        !is.na(out$redcap_form_instance),
+      NA,
+      out$redcap_form_instance
+    )
+
+    out <- relocate(out,
+                    "redcap_event_instance",
+                    .after = "redcap_form_instance")
   }
 
   # return


### PR DESCRIPTION
# Description
This PR remedies poor execution times introduced in the new `create_repeat_instance_vars` function from #126. The use of `mutate`/`case_when`, while great for readability, resulted in slow processing for databases with repeating events. Instead, base R haas been introduced and successfully cut down on the execution time illuminated by `profvis` in #132.

# Proposed Changes 
List changes below in bullet format:

- Convert `dplyr` method for creating repeat instance variables to base R

## Profvis Improvements

The following images use the Prodigy Test REDCap database which contains sample repeating events

### Previous execution times:
![image](https://user-images.githubusercontent.com/38384694/220754182-cdd6d86d-3536-411a-b72d-92e9c08182ef.png)

![image](https://user-images.githubusercontent.com/38384694/220754353-14d1a5bc-68e2-441d-80b8-09a13ff5ad7a.png)

### New execution times:

![image](https://user-images.githubusercontent.com/38384694/220753416-adc03dec-1ce9-4e7a-99cc-a4d9a25299b3.png)

![image](https://user-images.githubusercontent.com/38384694/220754465-631b42c9-9739-4ee5-a29b-6548db1e683f.png)

### Issue Addressed
**Closes #132**

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [NA] New/revised functions have associated tests
- [NA] New/revised functions that update downstream outputs have associated static testing files (`.RDS`) updated under `inst/testdata/create_test_data.R`
- [NA] New tests that make API calls use `httptest::with_mock_api` and any new mocks were added to `tests/testthat/fixtures/create_httptest_mocks.R`
- [x] New/revised functions use appropriate naming conventions
- [x] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR
- [x] Pre-release package version incremented using `usethis::use_dev_version()`

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases
