### PR TITLE
Small mocks fix

### DIFF
--- a/inst/httptest/redact.R
+++ b/inst/httptest/redact.R
@@ -8,7 +8,16 @@ function(response) {
   # Replace each token with a fake token
   purrr::reduce(
     names(fake_creds),
-    .f = ~gsub_response(.x, real_creds[[.y]], fake_creds[[.y]]),
+    .f = function(x, y) {
+      real <- real_creds[[y]]
+      fake <- fake_creds[[y]]
+      # If real credential not found don't replace anything
+      # Need this to ensure gsub_response doesn't fail in this case
+      if (real == "") {
+        return(x)
+      }
+      gsub_response(x, real, fake)
+    },
     .init = response
   )
 }


### PR DESCRIPTION
This PR fixes an issue where creating mocks fails when you don't have **all** of the credentials in `fake_credentials.csv` in your `.Renviron`. It's really only an issue when rerunning the vignettes where you may want to regenerate mocks for a vignette that uses only a subset of the test REDCaps without ensuring your `.Renviron` is totally up to date.