### PR TITLE
Update to v0.4.1.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: REDCapTidieR
 Type: Package
 Title: Extract 'REDCap' Databases into Tidy 'Tibble's
-Version: 0.4.1
+Version: 0.4.1.9000
 Authors@R: c(
     person("Richard", "Hanna", , "richardshanna91@gmail.com", role = c("aut", "cre")),
     person("Stephan", "Kadauke", , "kadaukes@chop.edu", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# REDCapTidieR (development version)
+
 # REDCapTidieR 0.4.1
 
 Version 0.4.1 (Released 2023-08-15)

--- a/R/write.R
+++ b/R/write.R
@@ -96,8 +96,6 @@ write_redcap_xlsx <- function(supertbl,
   # Create Sheet Names ----
   # Assign sheet values based on use of labels
   # Enforce max length of 31 per Excel restrictions
-  # openxlsx2 v0.8 fixes that (see janmarvin/openxlsx2#705),
-  # this is no longer required.
   sheet_vals <- if (use_labels_for_sheet_names) {
     # Remove special characters from labelled sheet names that cause
     # openxlsx2 worksheet failures
@@ -357,7 +355,6 @@ add_supertbl_toc <- function(wb,
                              column_width,
                              na_replace) {
   # To avoid XLSX indicators of "Number stored as text", change class type
-  # There is also a possibility to use openxlsx2::wb_add_ignore_error()
   convert_percent <- function(x) {
     class(x) <- c("numeric", "percentage")
     x


### PR DESCRIPTION
Minor update for the dev package version and removal of some comments per #160.

In testing, updating `convert_perc` to `openxlsx2::wb_add_ignore_error()` doesn't gain us much and makes the purpose a little more confusing. 

Removing handling of sheet value names using the combination of `str_trunc()` (to handle > 31 characters), punctuation removal, and whitespace removal caused failures for some complex names from our test databases. I think it's better to mandate some rules up front that ensures stability later, since it seems removal of our existing rules results in > 31 character errors and mishandling of "/" characters.