### PR TITLE
Update REDCapR to 1.2.0, update guess_max to Inf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     lobstr,
     lubridate,
     purrr,
-    REDCapR (>= 1.1.0),
+    REDCapR (>= 1.2.0),
     rlang,
     stringi,
     stringr,

--- a/R/read_redcap.R
+++ b/R/read_redcap.R
@@ -53,7 +53,7 @@
 #' from REDCapR API calls. Default `TRUE`.
 #' @param guess_max A positive [base::numeric] value
 #' passed to [readr::read_csv()] that specifies the maximum number of records to
-#' use for guessing column types. Default `.Machine$integer.max`.
+#' use for guessing column types. Default `Inf`.
 #' @param allow_mixed_structure A logical to allow for support of mixed repeating/non-repeating
 #' instruments. Setting to `TRUE` will treat the mixed instrument's non-repeating versions
 #' as repeating instruments with a single instance. Applies to longitudinal projects
@@ -80,7 +80,7 @@ read_redcap <- function(redcap_uri,
                         export_survey_fields = NULL,
                         export_data_access_groups = NULL,
                         suppress_redcapr_messages = TRUE,
-                        guess_max = .Machine$integer.max,
+                        guess_max = Inf,
                         allow_mixed_structure = getOption("redcaptidier.allow.mixed.structure", FALSE)) {
   check_arg_is_character(redcap_uri, len = 1, any.missing = FALSE)
   check_arg_is_character(token, len = 1, any.missing = FALSE)

--- a/man/read_redcap.Rd
+++ b/man/read_redcap.Rd
@@ -12,7 +12,7 @@ read_redcap(
   export_survey_fields = NULL,
   export_data_access_groups = NULL,
   suppress_redcapr_messages = TRUE,
-  guess_max = .Machine$integer.max,
+  guess_max = Inf,
   allow_mixed_structure = getOption("redcaptidier.allow.mixed.structure", FALSE)
 )
 }
@@ -46,7 +46,7 @@ from REDCapR API calls. Default \code{TRUE}.}
 
 \item{guess_max}{A positive \link[base:numeric]{base::numeric} value
 passed to \code{\link[readr:read_delim]{readr::read_csv()}} that specifies the maximum number of records to
-use for guessing column types. Default \code{.Machine$integer.max}.}
+use for guessing column types. Default \code{Inf}.}
 
 \item{allow_mixed_structure}{A logical to allow for support of mixed repeating/non-repeating
 instruments. Setting to \code{TRUE} will treat the mixed instrument's non-repeating versions


### PR DESCRIPTION
# Description
This PR addresses a backlog issue that can now be fixed with the release of [REDCapR 1.2.0](https://cran.r-project.org/web/packages/REDCapR/index.html).

In short, there was an assertion in the REDCapR code that failed on supplying `Inf` to `guess_max`, which we want to have as the default when guessing column types with the `readr` package. It would result in this error from our UI:

```
Error in `read_redcap()`:
✖ The REDCapR export operation was not successful.
! An unexpected error occured.
ℹ This means that you probably discovered a bug!
ℹ Please consider submitting a bug report here: <https://github.com/CHOP-CGTInformatics/REDCapTidieR/issues>.
Caused by error in `redcap_read_oneshot()` at REDCapTidieR/R/read_redcap.R:182:5:
! Assertion on 'guess_max' failed: Must be of type 'integerish', but element 1 is not in integer range.
Run `rlang::last_trace()` to see where the error occurred.
```

Now that REDCapR is updated, we can use `Inf` as the default.

# Proposed Changes 
List changes below in bullet format:

- Switch out `.Machine$integer.max` for `Inf` as the default value for `guess_max` in `read_redcap()`
- Update `renv` lockfile to use REDCapR 1.2.0
- Update DESCRIPTION file Imports section for REDCapR >= 1.2.0

### Issue Addressed
**Closes #145**

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [NA] New/revised functions have associated tests
   - Not making new tests as all of our API tests would fail with the default `guess_max` value if it still wasn't working
- [NA] New/revised functions that update downstream outputs have associated static testing files (`.RDS`) updated under `inst/testdata/create_test_data.R`
- [x] New/revised functions use appropriate naming conventions
- [x] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR
- [NA] Pre-release package version incremented using `usethis::use_version()`
   - All to be wrapped up in the next REDCapTidieR release version

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases
