### PR TITLE
Fix `check_extra_field_values` assignment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: REDCapTidieR
 Type: Package
 Title: Extract 'REDCap' Databases into Tidy 'Tibble's
-Version: 1.2.2
+Version: 1.2.2.9000
 Authors@R: c(
     person("Richard", "Hanna", , "hannar1@chop.edu", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0005-6496-8154")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# REDCapTidieR (development version)
+
 # REDCapTidieR 1.2.2
 
 - Fixed a bug where, when using `raw_or_label = "label"` and requesting DAGs, only raw values for DAGs would be retrieved

--- a/R/utils.R
+++ b/R/utils.R
@@ -495,10 +495,14 @@ multi_choice_to_labels <- function(db_data, db_metadata, raw_or_label = "label",
       )
 
       if (!getOption("redcaptidier.allow.mdc", FALSE)) {
-        extra_field_values[i] <- check_extra_field_values(
+        check_extra_field_values_res <- check_extra_field_values(
           db_data[[field_name]],
           names(parse_labels_output)
         )
+
+        if (!is.null(check_extra_field_values_res)) {
+          extra_field_values[i] <- check_extra_field_values_res
+        }
       }
 
       # Replace values from db_data$(field_name) with label values from


### PR DESCRIPTION
# Description
This PR fixes a small bug that was causing `check_extra_field_values` to report the wrong field when `REDCapTidieR` finds data values that don't match any labels in the metadata.

# Proposed Changes 
- Update `multi_choice_to_labels()` to check if the result of `check_extra_field_values()` is `NULL` before replacing values.

The issue was that indexing into a `list` with `NULL` **always** drops the item you're indexing even it was already `NULL`:

```r
x <- list(1, NULL, 3)

x[2] <- NULL

x

#> [[1]]
#> [1] 1
#> 
#> [[2]]
#> [1] 3
```

### PR Checklist
Before submitting this PR, please check and verify below that the submission meets the below criteria:

- [ ] New/revised functions have associated tests
- [x] New/revised functions that update downstream outputs have associated static testing files (`.RDS`) updated under `inst/testdata/create_test_data.R`
- [x] New/revised functions use appropriate naming conventions
- [x] New/revised functions don't repeat code
- [x] Code changes are less than **250** lines total
- [x] Issues linked to the PR using [GitHub's list of keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] The appropriate reviewer is assigned to the PR
- [x] The appropriate developers are assigned to the PR
- [x] Pre-release package version incremented using `usethis::use_version()`

# Code Review
This section to be used by the reviewer and developers during Code Review after PR submission

### Code Review Checklist

- [ ] I checked that new files follow naming conventions and are in the right place
- [ ] I checked that documentation is complete, clear, and without typos
- [ ] I added/edited comments to explain "why" not "how"
- [ ] I checked that all new variable and function names follow naming conventions
- [ ] I checked that new tests have been written for key business logic and/or bugs that this PR fixes
- [ ] I checked that new tests address important edge cases
